### PR TITLE
Fix `xcmInteriorKey` conversion

### DIFF
--- a/__tests__/assetRegistry.test.ts
+++ b/__tests__/assetRegistry.test.ts
@@ -144,6 +144,31 @@ describe('AssetRegistry', () => {
       },
     });
 
+    // From the perspective of another parachain:
+    expect(
+      AssetRegistry.xcmInteriorToMultiAsset(usdcXcmInteriorKey, true, 2001)
+    ).toStrictEqual({
+      parents: 1,
+      interior: {
+        X2: [
+          { parachain: 2000 },
+          { generalKey: '0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce' },
+        ],
+      },
+    });
+
+    // From the perspective of the parachain itself the junctions will be different.
+    expect(
+      AssetRegistry.xcmInteriorToMultiAsset(usdcXcmInteriorKey, true, 2000)
+    ).toStrictEqual({
+      parents: 0,
+      interior: {
+        X1: [
+          { generalKey: '0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce' },
+        ],
+      },
+    });
+
     const usdtXcmInteriorKey = [
       { network: 'polkadot' },
       { parachain: 1000 },
@@ -163,309 +188,5 @@ describe('AssetRegistry', () => {
         ],
       },
     });
-  });
-
-  test('Getting assets on Acala works', async () => {
-    const assets = await AssetRegistry.getAssetsOnBlockchain(
-      'polkadot',
-      'acala'
-    );
-
-    expect(assets).toStrictEqual([
-      {
-        asset: {
-          Erc20: '0x07df96d1341a7d16ba1ad431e2c847d978bc2bce',
-        },
-        name: 'USD Coin (Portal from Ethereum)',
-        symbol: 'USDCet',
-        decimals: 6,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce' },
-        ],
-      },
-      {
-        asset: {
-          Erc20: '0x54a37a01cd75b616d63e0ab665bffdb0143c52ae',
-        },
-        name: 'DAI Stablecoin (Portal)',
-        symbol: 'DAI',
-        decimals: 18,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae' },
-        ],
-      },
-      {
-        asset: {
-          Erc20: '0x5a4d6acdc4e3e5ab15717f407afe957f7a242578',
-        },
-        name: 'Wrapped Ether (Portal)',
-        symbol: 'WETH',
-        decimals: 18,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x025a4d6acdc4e3e5ab15717f407afe957f7a242578' },
-        ],
-      },
-      {
-        asset: {
-          Erc20: '0xc80084af223c8b598536178d9361dc55bfda6818',
-        },
-        name: 'Wrapped Bitcoin (Portal)',
-        symbol: 'WBTC',
-        decimals: 8,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x02c80084af223c8b598536178d9361dc55bfda6818' },
-        ],
-      },
-      {
-        asset: {
-          Erc20: '0xf4c723e61709d90f89939c1852f516e373d418a8',
-        },
-        name: 'ApeCoin (Portal)',
-        symbol: 'APE',
-        decimals: 18,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x02f4c723e61709d90f89939c1852f516e373d418a8' },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '0',
-        },
-        name: 'Moonbeam',
-        symbol: 'GLMR',
-        decimals: 18,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2004 },
-          { palletInstance: 10 },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '1',
-        },
-        name: 'Parallel',
-        symbol: 'PARA',
-        decimals: 12,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2012 },
-          { generalKey: '0x50415241' },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '10',
-        },
-        name: 'Unique Network',
-        symbol: 'UNQ',
-        decimals: 18,
-        xcmInteriorKey: [{ network: 'polkadot' }, { parachain: 2037 }],
-      },
-      {
-        asset: {
-          ForeignAsset: '11',
-        },
-        name: 'Crust Parachain Native Token',
-        symbol: 'CRU',
-        decimals: 12,
-        xcmInteriorKey: [{ network: 'polkadot' }, { parachain: 2008 }],
-      },
-      {
-        asset: {
-          ForeignAsset: '12',
-        },
-        name: 'Tether USD',
-        symbol: 'USDT',
-        decimals: 6,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 1000 },
-          { palletInstance: 50 },
-          { generalIndex: 1984 },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '2',
-        },
-        name: 'Astar Native Token',
-        symbol: 'ASTR',
-        decimals: 18,
-        xcmInteriorKey: [{ network: 'polkadot' }, { parachain: 2006 }],
-      },
-      {
-        asset: {
-          ForeignAsset: '3',
-        },
-        name: 'interBTC',
-        symbol: 'IBTC',
-        decimals: 8,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2032 },
-          { generalKey: '0x0001' },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '4',
-        },
-        name: 'Interlay',
-        symbol: 'INTR',
-        decimals: 10,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2032 },
-          { generalKey: '0x0002' },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '5',
-        },
-        name: 'Wrapped Bitcoin',
-        symbol: 'WBTC',
-        decimals: 8,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 1000 },
-          { palletInstance: 50 },
-          { generalIndex: 21 },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '6',
-        },
-        name: 'Wrapped Ether',
-        symbol: 'WETH',
-        decimals: 18,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 1000 },
-          { palletInstance: 50 },
-          { generalIndex: 100 },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '7',
-        },
-        name: 'Equilibrium',
-        symbol: 'EQ',
-        decimals: 9,
-        xcmInteriorKey: [{ network: 'polkadot' }, { parachain: 2011 }],
-      },
-      {
-        asset: {
-          ForeignAsset: '8',
-        },
-        name: 'Equilibrium USD',
-        symbol: 'EQD',
-        decimals: 9,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2011 },
-          { generalKey: '0x657164' },
-        ],
-      },
-      {
-        asset: {
-          ForeignAsset: '9',
-        },
-        name: 'Phala Token',
-        symbol: 'PHA',
-        decimals: 12,
-        xcmInteriorKey: [{ network: 'polkadot' }, { parachain: 2035 }],
-      },
-      {
-        asset: {
-          LiquidCrowdloan: '13',
-        },
-        name: 'Liquid Crowdloan DOT',
-        symbol: 'LcDOT',
-        decimals: 10,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x040d000000' },
-        ],
-      },
-      {
-        asset: {
-          StableAsset: '0',
-        },
-        name: 'Taiga DOT',
-        symbol: 'tDOT',
-        decimals: 10,
-      },
-      {
-        asset: {
-          Token: 'ACA',
-        },
-        name: 'Acala',
-        symbol: 'ACA',
-        decimals: 12,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x0000' },
-        ],
-      },
-      {
-        asset: {
-          Token: 'AUSD',
-        },
-        name: 'aUSD SEED',
-        symbol: 'aSEED',
-        decimals: 12,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x0001' },
-        ],
-      },
-      {
-        asset: {
-          Token: 'DOT',
-        },
-        name: 'Polkadot',
-        symbol: 'DOT',
-        decimals: 10,
-        xcmInteriorKey: [{ network: 'polkadot' }, 'here'],
-      },
-      {
-        asset: {
-          Token: 'LDOT',
-        },
-        name: 'Liquid DOT',
-        symbol: 'LDOT',
-        decimals: 10,
-        xcmInteriorKey: [
-          { network: 'polkadot' },
-          { parachain: 2000 },
-          { generalKey: '0x0003' },
-        ],
-      },
-      {
-        asset: {
-          Token: 'TAP',
-        },
-        name: 'Tapio',
-        symbol: 'TAP',
-        decimals: 12,
-      },
-    ]);
   });
 });

--- a/src/utils/assetRegistry.ts
+++ b/src/utils/assetRegistry.ts
@@ -20,8 +20,8 @@ type MultiAsset = {
 };
 
 type ReserveChain = {
-  parachainId: number,
-  junctionIndex: number,
+  parachainId: number;
+  junctionIndex: number;
 };
 
 const xcmGAR =
@@ -58,12 +58,13 @@ class AssetRegistry {
   public static xcmInteriorToMultiAsset(
     xcmInteriorKey: any[],
     isParachain: boolean,
-    paraId?: number,
+    paraId?: number
   ): MultiAsset {
-    // The first 'junction' is actually just the specifying the network and we
+    // The first `junction` is actually just the specifying the network and we
     // don't need that in `MultiAsset`.
     const junctionCount = xcmInteriorKey.length - 1;
-    const { parachainId: assetParaId, junctionIndex } = this.getAssetReserveParchainId(xcmInteriorKey);
+    const { parachainId: assetParaId, junctionIndex } =
+      this.getAssetReserveParachainId(xcmInteriorKey);
 
     if (assetParaId >= 0 && assetParaId == paraId) {
       xcmInteriorKey.splice(junctionIndex, 1);
@@ -81,9 +82,9 @@ class AssetRegistry {
         return {
           parents: 0,
           interior: {
-            [x]: junctions
-          }
-        }
+            [x]: junctions,
+          },
+        };
       }
     }
 
@@ -107,7 +108,9 @@ class AssetRegistry {
     };
   }
 
-  private static getAssetReserveParchainId(xcmInteriorKey: any[]): ReserveChain {
+  private static getAssetReserveParachainId(
+    xcmInteriorKey: any[]
+  ): ReserveChain {
     // -1 will indicate that the reserve chain is actually the relay chain.
     let parachainId = -1;
     let index = -1;
@@ -122,9 +125,9 @@ class AssetRegistry {
   }
 
   private static isHere(xcmInteriorKey: any[], junctionCount: number): boolean {
-
-    return junctionCount == 1 &&
-      xcmInteriorKey[1].toString().toLowerCase() == 'here'
+    return (
+      junctionCount == 1 && xcmInteriorKey[1].toString().toLowerCase() == 'here'
+    );
   }
 
   private static getJunctions(

--- a/src/utils/assetRegistry.ts
+++ b/src/utils/assetRegistry.ts
@@ -13,10 +13,15 @@ type Asset = {
 type MultiAsset = {
   parents: number;
   interior:
-    | 'Here'
-    | {
-        [key: string]: Asset[];
-      };
+  | 'Here'
+  | {
+    [key: string]: Asset[];
+  };
+};
+
+type ReserveChain = {
+  parachainId: number,
+  junctionIndex: number,
 };
 
 const xcmGAR =
@@ -52,17 +57,39 @@ class AssetRegistry {
 
   public static xcmInteriorToMultiAsset(
     xcmInteriorKey: any[],
-    isParachain: boolean
+    isParachain: boolean,
+    paraId?: number,
   ): MultiAsset {
     // The first 'junction' is actually just the specifying the network and we
     // don't need that in `MultiAsset`.
     const junctionCount = xcmInteriorKey.length - 1;
+    const { parachainId: assetParaId, junctionIndex } = this.getAssetReserveParchainId(xcmInteriorKey);
+
+    if (assetParaId >= 0 && assetParaId == paraId) {
+      xcmInteriorKey.splice(junctionIndex, 1);
+      const junctionCount = xcmInteriorKey.length - 1;
+
+      if (this.isHere(xcmInteriorKey, junctionCount)) {
+        return {
+          parents: 0,
+          interior: 'Here',
+        };
+      } else {
+        const junctions = this.getJunctions(xcmInteriorKey, junctionCount);
+        const x = `X${junctionCount}`;
+
+        return {
+          parents: 0,
+          interior: {
+            [x]: junctions
+          }
+        }
+      }
+    }
+
     const parents = isParachain ? 1 : 0;
 
-    if (
-      junctionCount == 1 &&
-      xcmInteriorKey[1].toString().toLowerCase() == 'here'
-    ) {
+    if (this.isHere(xcmInteriorKey, junctionCount)) {
       return {
         parents,
         interior: 'Here',
@@ -80,13 +107,33 @@ class AssetRegistry {
     };
   }
 
+  private static getAssetReserveParchainId(xcmInteriorKey: any[]): ReserveChain {
+    // -1 will indicate that the reserve chain is actually the relay chain.
+    let parachainId = -1;
+    let index = -1;
+    xcmInteriorKey.forEach((junction, i) => {
+      if (junction.parachain) {
+        parachainId = junction.parachain;
+        index = i;
+      }
+    });
+
+    return { parachainId, junctionIndex: index };
+  }
+
+  private static isHere(xcmInteriorKey: any[], junctionCount: number): boolean {
+
+    return junctionCount == 1 &&
+      xcmInteriorKey[1].toString().toLowerCase() == 'here'
+  }
+
   private static getJunctions(
     xcmInteriorKey: any[],
     junctionCount: number
   ): any[] {
     return xcmInteriorKey.slice(1, junctionCount + 1);
   }
-  
+
   public static async isSupportedOnBothChains(
     network: 'polkadot' | 'kusama',
     chainA: string,


### PR DESCRIPTION
There was a problem in the code in case the asset is on a parachain itself. In this case, the result would still specify the parachain junction, but that is not correct, since from the perspective of the parachain only the other junctions need to be specified.

Also, removed the test for getting all the assets on Acala, since the assets change pretty frequently.